### PR TITLE
FEATURE: Prepare created_at to be a known date format

### DIFF
--- a/Classes/Domain/Index/TweetIndexer.php
+++ b/Classes/Domain/Index/TweetIndexer.php
@@ -79,14 +79,20 @@ class TweetIndexer extends AbstractIndexer
 
     /**
      * @throws InvalidArgumentException
+     * @thows \Exception
      */
     protected function prepareRecord(array &$record)
     {
-        parent::prepareRecord($record);
-
         if (!isset($record['id_str'])) {
             throw new \InvalidArgumentException('No "id_str" available for tweet.', 1520933234);
         }
+
+        if (isset($record['created_at'])) {
+            $record['created_at'] = (new \DateTime($record['created_at']))
+                ->format(\DateTime::ISO8601);
+        }
+
+        parent::prepareRecord($record);
 
         $record['search_identifier'] = $record['id_str'];
     }


### PR DESCRIPTION
Format created_at to be ISO8601 formated date time. This way we have a
common format for date time information and Elasticsearch is able to
parse information out of the box as date.